### PR TITLE
Add project lifecycle badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![img](https://img.shields.io/badge/Lifecycle-Retired-d45500)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
+
 # Law Society Demo
 
 Proof-of-concept for authenticating to a website using Keycloak and vc-authn-oidc


### PR DESCRIPTION
Resolves #32 

Status chosen is `retired` since we are not planning on updating/using the project for much longer, as far as my understanding goes.